### PR TITLE
Updated the family tree generator

### DIFF
--- a/CodingChallenge.FamilyTree.Tests/FamilyTreeGenerator.cs
+++ b/CodingChallenge.FamilyTree.Tests/FamilyTreeGenerator.cs
@@ -13,10 +13,11 @@ namespace CodingChallenge.FamilyTree.Tests
             var hierarchySpec = Builder<HierarchySpec<Person>>.CreateNew()
                 .With(h => h.AddMethod, (p1, p2) => p1.Descendants.Add(p2))
                 .With(h => h.Depth = 7)
-                .With(h => h.MaximumChildren = 3)
+                .With(h => h.MinimumChildren = 2)
+                .With(h => h.MaximumChildren = 4)
                 .With(h => h.NumberOfRoots = 1).Build();
 
-            var person = Builder<Person>.CreateListOfSize(1100).BuildHierarchy(hierarchySpec).First();
+            var person = Builder<Person>.CreateListOfSize(5461).BuildHierarchy(hierarchySpec).First();
 
             return person;
         }


### PR DESCRIPTION
Sometimes the family tree generator does not generate a tree large enough to pass test cases with index's 33 or 22. This PR updated the HierarchySpec to make sure that it always generates a tree large enough for the tests to work correctly.